### PR TITLE
Fix wrong boolean conversion for striphtml

### DIFF
--- a/Configuration/FlexForm/flexform.xml
+++ b/Configuration/FlexForm/flexform.xml
@@ -167,10 +167,10 @@
 									</numIndex>
 									<numIndex index="2" type="array">
 										<numIndex index="0">LLL:EXT:gkh_rss_import/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.striphtml.I.2</numIndex>
-										<numIndex index="1">2</numIndex>
+										<numIndex index="1">0</numIndex>
 									</numIndex>
 								</items>
-								<default>2</default>
+								<default>0</default>
 								<minitems>0</minitems>
 								<maxitems>1</maxitems>
 								<size>1</size>


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 v10.4 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been tested on PHP 7.3.x
* [ ] Changes have been tested on PHP 7.4.x
* [ ] Changes have been tested on PHP 8.0.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

Currently HTML is always being stripped from the RSS items title and description because the option "No" for the striphtml setting has a value of "2" which is then converted to "true".