### PR TITLE
fix striphtml parameter interpretation

### DIFF
--- a/Classes/Controller/RssImportController.php
+++ b/Classes/Controller/RssImportController.php
@@ -132,7 +132,7 @@ class RssImportController extends AbstractPlugin
             $this->rssService->setCacheTime((int)$this->conf['flexCache']);
         }
 
-        if ((bool)$this->conf['stripHTML']) {
+        if ($this->conf['stripHTML'] == 1) {
             $this->rssService->setStripHTML(true);
         }
 


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 v10.4 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been tested on PHP 7.3.x
* [ ] Changes have been tested on PHP 7.4.x
* [ ] Changes have been tested on PHP 8.0.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

Currently, HTML will always be stripped from the RSS feed, because the flexform value "striphtml" is incorrectly cast to a boolean value. This pull request fixes the interpretation of the parameter "striphtml".

