### PR TITLE
[BUGFIX] description should be optional

### DIFF
--- a/Classes/Controller/RssImportController.php
+++ b/Classes/Controller/RssImportController.php
@@ -170,6 +170,10 @@ class RssImportController extends AbstractPlugin
         return file_get_contents($template);
     }
 
+    /**
+     * @return string
+     * @throws NoSuchCacheException
+     */
     protected function render(): string
     {
         $markerArray['###BOX###'] = $this->pi_classParam('rss_box');
@@ -178,7 +182,9 @@ class RssImportController extends AbstractPlugin
         $rss = $this->rssService->getFeed();
         if (is_array($rss)) {
             $rss['title'] = strip_tags($this->rssService->unHtmlEntities(strip_tags($rss['title'])));
-            $rss['description'] = strip_tags($this->rssService->unHtmlEntities(strip_tags($rss['description'])));
+            if (isset($rss['description'])) {
+                $rss['description'] = strip_tags($this->rssService->unHtmlEntities(strip_tags($rss['description'])));
+            }
 
             $target = $this->getTarget();
 


### PR DESCRIPTION
Description should be optional in an RSS import.

Check if `$rss['description']` exists before trying to decode it. This will otherwise throw the error:
`Uncaught TYPO3 Exception: strip_tags() expects parameter 1 to be string, null given`