### PR TITLE
[BUGFIX] Invalid cache identifier for image with parameters

### DIFF
--- a/Classes/Controller/RssImportController.php
+++ b/Classes/Controller/RssImportController.php
@@ -184,6 +184,8 @@ class RssImportController extends AbstractPlugin
             $rss['title'] = strip_tags($this->rssService->unHtmlEntities(strip_tags($rss['title'])));
             if (isset($rss['description'])) {
                 $rss['description'] = strip_tags($this->rssService->unHtmlEntities(strip_tags($rss['description'])));
+            } else {
+                $rss['description'] = '';
             }
 
             $target = $this->getTarget();
@@ -272,7 +274,7 @@ class RssImportController extends AbstractPlugin
     {
         $imageCache = $this->cacheManager->getCache(self::CACHE_IDENTIFIER);
 
-        $fileExtension = substr($this->getFileName($imageUrl), -4);
+        $fileExtension = '.' . $this->getFileExtensionFromUrl($imageUrl);
         $cacheIdentifier = sha1($imageUrl . '_' . $fileExtension) . $fileExtension;
         if (!$imageCache->has($cacheIdentifier)) {
             $buff = GeneralUtility::getURL($imageUrl);
@@ -284,6 +286,12 @@ class RssImportController extends AbstractPlugin
         /** @var Typo3TempSimpleFileBackend $imageCacheBackend */
         $imageCacheBackend = $imageCache->getBackend();
         return $imageCacheBackend->getCacheDirectory() . $cacheIdentifier;
+    }
+
+    protected function getFileExtensionFromUrl(string $url): string
+    {
+        $urlParts = parse_url($url);
+        return pathinfo($urlParts['path'], PATHINFO_EXTENSION);
     }
 
     protected function getSubPart(string $template, string $marker): string
@@ -492,19 +500,6 @@ class RssImportController extends AbstractPlugin
             return $text;
         }
         return $this->cObj->cropHTML($text, $itemLength . '|...|1');
-    }
-
-    /**
-     * Get filename from url
-     *
-     * @param string $url : url to the file
-     *
-     * @return string
-     */
-    protected function getFileName(string $url): string
-    {
-        $parts = explode('/', $url);
-        return ($parts[count($parts) - 1] === '') ? $parts[count($parts) - 2] : $parts[count($parts) - 1];
     }
 
     /**

--- a/Tests/Unit/Controller/RssImportControllerTest.php
+++ b/Tests/Unit/Controller/RssImportControllerTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace GertKaaeHansen\GkhRssImport\Tests\Unit\Controller;
 
 use GertKaaeHansen\GkhRssImport\Controller\RssImportController;
+use GertKaaeHansen\GkhRssImport\Tests\Unit\Fixtures\Controller\RssImportControllerFixture;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use Prophecy\Argument;
 use TYPO3\CMS\Core\Cache\CacheManager;
@@ -157,5 +158,18 @@ class RssImportControllerTest extends UnitTestCase
         $result = $this->subject->cropHTML($input, []);
 
         self::assertEquals($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getCachedImageLocation(): void
+    {
+        $subject = new RssImportControllerFixture();
+        $result = $subject->getFileExtensionFromUrl(
+            'https://i1.wp.com/example.com/wp-content/uploads/2020/cropped-logo.png?fit=32%2C32&#038;ssl=1'
+        );
+
+        self::assertEquals('png', $result);
     }
 }

--- a/Tests/Unit/Fixtures/Controller/RssImportControllerFixture.php
+++ b/Tests/Unit/Fixtures/Controller/RssImportControllerFixture.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * (c) Gert Kaae Hansen, Simon Schaufelberger
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace GertKaaeHansen\GkhRssImport\Tests\Unit\Fixtures\Controller;
+
+use GertKaaeHansen\GkhRssImport\Controller\RssImportController;
+
+class RssImportControllerFixture extends RssImportController
+{
+    public function getFileExtensionFromUrl(string $url): string
+    {
+        return parent::getFileExtensionFromUrl($url);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #13 

## Prerequisites

* [x] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 v10.4 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been tested on PHP 7.3.x
* [x] Changes have been tested on PHP 7.4.x
* [ ] Changes have been tested on PHP 8.0.x
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

If image url contains additional parameters, the file extension is not correct